### PR TITLE
grpczk.updateServerList nil pointer 에러

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 apache zookeeper 를 통해서 advertise 된 grpc 서버의 정보를 실시간으로 감시하여 grpc client에서 grpc server list 를 갱신하도록 기능을 제공한다
 
 # release #
-2023.11.09 v1.0.4
+2023.11.09 v1.0.2
 - [updateServerList()의 nil 포인트 에러](https://github.com/fatima-go/grpczk/issues/1) 해결
 - github.com/go-zookeeper/zk 버전 1.0.3 업데이트
 - google.golang.org/protobuf 버전 v1.31.0 업데이트

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# grpczk #
+apache zookeeper 를 통해서 advertise 된 grpc 서버의 정보를 실시간으로 감시하여 grpc client에서 grpc server list 를 갱신하도록 기능을 제공한다
+
+# release #
+2023.11.09 v1.0.4
+- [updateServerList()의 nil 포인트 에러](https://github.com/fatima-go/grpczk/issues/1) 해결
+- github.com/go-zookeeper/zk 버전 1.0.3 업데이트
+- google.golang.org/protobuf 버전 v1.31.0 업데이트
+- google.golang.org/grpc 버전 v1.59.0 업데이트

--- a/go.mod
+++ b/go.mod
@@ -3,15 +3,15 @@ module github.com/fatima-go/grpczk
 go 1.17
 
 require (
-	github.com/go-zookeeper/zk v1.0.2
-	google.golang.org/grpc v1.44.0
+	github.com/go-zookeeper/zk v1.0.3
+	google.golang.org/grpc v1.59.0
 )
 
 require (
-	github.com/golang/protobuf v1.4.3 // indirect
-	golang.org/x/net v0.0.0-20200822124328-c89045814202 // indirect
-	golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd // indirect
-	golang.org/x/text v0.3.0 // indirect
-	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
-	google.golang.org/protobuf v1.25.0 // indirect
+	github.com/golang/protobuf v1.5.3 // indirect
+	golang.org/x/net v0.14.0 // indirect
+	golang.org/x/sys v0.11.0 // indirect
+	golang.org/x/text v0.12.0 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20230822172742-b8732ec3820d // indirect
+	google.golang.org/protobuf v1.31.0 // indirect
 )

--- a/zk_client.go
+++ b/zk_client.go
@@ -205,6 +205,11 @@ func (z *ZkClientServant) watchNode(znodePath string, children []string, ch <-ch
 			continue
 		}
 
+		// 연결이 종료되었을 경우 updateServerList 호출을 skip
+		if e.State == zk.StateDisconnected {
+			continue
+		}
+
 		err = updateServerList(znodePath, children)
 		if err != nil {
 			if z.errorLogger != nil {

--- a/zk_client_resolve.go
+++ b/zk_client_resolve.go
@@ -65,7 +65,7 @@ func registServiceResolver(serviceName string, initialServerList []string) {
 func unregistServiceResolver(serviceName string) {
 	rmu.Lock()
 	defer rmu.Unlock()
-	resolveMap[serviceName] = nil
+	delete(resolveMap, serviceName)
 	zk.DefaultLogger.Printf("resolver unregisted %s", serviceName)
 }
 
@@ -79,7 +79,7 @@ func updateServerList(serviceName string, newServerList []string) error {
 
 	updater, ok := resolveMap[serviceName]
 	if !ok {
-		return errNotfoundServiceName
+		return nil // nothing...
 	}
 
 	return updater.UpdateServerList(newServerList)


### PR DESCRIPTION
관련 이슈 : [updateServerList()의 nil 포인트 에러](https://github.com/fatima-go/grpczk/issues/1)
먼저 의견 나온데로,
1. unregistServiceResolver() 에서 resolveMap 의 키 삭제시 delete 함수 사용
2. updateServerList 에서 resolveMap에 관련 키가 존재하지 않을 경우 (기존에는 에러를 리턴했으나) return nil 처리

다른 부분은 go.mod 에서 grace 관련 lib 을 최신 버전으로 모두 업데이트 했습니다.

zk_client_resolve.go 파일만 체크해 주시면 될것 같습니다. 