### PR TITLE
zk 노드를 통해 서버 목록 처리시 클라이언트에 확장성 제공

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 apache zookeeper 를 통해서 advertise 된 grpc 서버의 정보를 실시간으로 감시하여 grpc client에서 grpc server list 를 갱신하도록 기능을 제공한다
 
 # release #
+2024.1.15 v1.0.5
+- [zk 노드를 통해 서버 목록 처리시 클라이언트에 확장성 제공 ](https://github.com/fatima-go/grpczk/issues/9)
 2024.1.11 v1.0.4
 - [znode 의 서비스에 별도 로드밸런서를 제공하는 인터페이스 추가](https://github.com/fatima-go/grpczk/issues/6)
 2023.11.29 v1.0.3

--- a/zk_client_resolve.go
+++ b/zk_client_resolve.go
@@ -37,7 +37,8 @@ const (
 
 // ZKServiceHelper zk 연결시 추가적으로 사용할 수 있는 인터페이스를 제공한다
 type ZKServiceHelper interface {
-	GetBalancerName() string // balancer name 제공 빈 값이면 디폴트 round robin 사용
+	UpdateServerList(foundAddrList []string) []string // 서버 목록을 수정한 결과를 받는다
+	GetBalancerName() string                          // balancer name 제공 빈 값이면 디폴트 round robin 사용
 }
 
 // resolveMap
@@ -151,6 +152,11 @@ func (r *grpczkResolver) SetConnection(cc resolver.ClientConn) {
 func (r *grpczkResolver) UpdateServerList(addrList []string) error {
 	if r.cc == nil {
 		return fmt.Errorf("%s has no ClientConn", r.serviceName)
+	}
+
+	helper, ok := serviceHelperMap[r.serviceName]
+	if ok {
+		addrList = helper.UpdateServerList(addrList)
 	}
 
 	zk.DefaultLogger.Printf("%s update server list : %v", r.serviceName, addrList)


### PR DESCRIPTION
[관련 이슈 링크](https://github.com/fatima-go/grpczk/issues/9)