### PR TITLE
명시적 Close() 처리시 별도 이벤트 처리 go func에 의한 오동작 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,12 @@ apache zookeeper 를 통해서 advertise 된 grpc 서버의 정보를 실시간�
 
 # release #
 
+2025.03.10 v1.0.9
+- [명시적 Close() 처리시 별도 이벤트 처리 go func에 의한 오동작 수정](https://github.com/fatima-go/grpczk/issues/17)
+
 2025.02.27 v1.0.8
 - [명시적 Close() 호출 이후에 nil 포인트 에러 대응](https://github.com/fatima-go/grpczk/issues/15)
-- 
+
 2025.02.25 v1.0.7
 - [disconnect 되었을때 연결 재설정 코드 필요](https://github.com/fatima-go/grpczk/issues/13)
 

--- a/zk_servant.go
+++ b/zk_servant.go
@@ -118,9 +118,6 @@ func (z *ZkServant) Connect() error {
 }
 
 func (z *ZkServant) Close() {
-	z.mutex.Lock()
-	defer z.mutex.Unlock()
-
 	z.forceCloseZkConn()
 	z.pathSet = nil
 }
@@ -176,6 +173,9 @@ func (z *ZkServant) processZkEvent(event zk.Event) bool {
 }
 
 func (z *ZkServant) forceCloseZkConn() bool {
+	z.mutex.Lock()
+	defer z.mutex.Unlock()
+
 	if z.zkConn == nil {
 		return false
 	}
@@ -194,7 +194,9 @@ func (z *ZkServant) reconnectUntilSuccess() {
 			break
 		}
 
-		z.errorLogger.Printf("reconnectUntilSuccess error : %s", err.Error())
+		if z.errorLogger != nil {
+			z.errorLogger.Printf("reconnectUntilSuccess error : %s", err.Error())
+		}
 		time.Sleep(time.Second)
 	}
 }


### PR DESCRIPTION
[관련 이슈](https://github.com/fatima-go/grpczk/issues/17)