### PR TITLE
Zookeeper 서버의 IP 가 변경되었을때 대응 로직 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@ apache zookeeper 를 통해서 advertise 된 grpc 서버의 정보를 실시간�
 
 # release #
 
+2025.04.03 v1.1.0
+- [Zookeeper 서버의 IP 가 변경되었을때 대응 로직 추가](https://github.com/fatima-go/grpczk/issues/19)
+
 2025.03.10 v1.0.9
 - [명시적 Close() 처리시 별도 이벤트 처리 go func에 의한 오동작 수정](https://github.com/fatima-go/grpczk/issues/17)
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/fatima-go/grpczk
 go 1.17
 
 require (
-	github.com/go-zookeeper/zk v1.0.3
+	github.com/go-zookeeper/zk v1.0.4
 	github.com/stretchr/testify v1.9.0
 	google.golang.org/grpc v1.59.0
 )

--- a/requery_dnshost_provider.go
+++ b/requery_dnshost_provider.go
@@ -50,8 +50,8 @@ type lookupTimeoutOption struct {
 
 // WithLookupTimeout returns a RequeryDNSHostProviderOption that sets the lookup timeout.
 func WithLookupTimeout(timeout time.Duration) RequeryDNSHostProviderOption {
-	if timeout < 0 {
-		timeout = _defaultLookupTimeout // minimum
+	if timeout < time.Second {
+		timeout = time.Second // minimum
 	}
 
 	return lookupTimeoutOption{

--- a/requery_dnshost_provider.go
+++ b/requery_dnshost_provider.go
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2025 github.com/fatima-go
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @project fatima-core
+ * @author dave_01
+ * @date 25. 4. 2. 오후 5:23
+ *
+ */
+
+package grpczk
+
+import (
+	"context"
+	"fmt"
+	"github.com/go-zookeeper/zk"
+	"math/rand"
+	"net"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	_defaultLookupTimeout   = 3 * time.Second
+	_defaultRequeryInterval = 5 * time.Second
+)
+
+type lookupHostFn func(context.Context, string) ([]string, error)
+
+// RequeryDNSHostProviderOption is an option for the RequeryDNSHostProvider.
+type RequeryDNSHostProviderOption interface {
+	apply(*RequeryDNSHostProvider)
+}
+
+type lookupTimeoutOption struct {
+	timeout time.Duration
+}
+
+// WithLookupTimeout returns a RequeryDNSHostProviderOption that sets the lookup timeout.
+func WithLookupTimeout(timeout time.Duration) RequeryDNSHostProviderOption {
+	if timeout < 0 {
+		timeout = _defaultLookupTimeout // minimum
+	}
+
+	return lookupTimeoutOption{
+		timeout: timeout,
+	}
+}
+
+func (o lookupTimeoutOption) apply(provider *RequeryDNSHostProvider) {
+	provider.lookupTimeout = o.timeout
+}
+
+type requeryIntervalOption struct {
+	interval time.Duration
+}
+
+// WithLookupTimeout returns a RequeryDNSHostProviderOption that sets the lookup timeout.
+func WithRequeryInterval(interval time.Duration) RequeryDNSHostProviderOption {
+	if interval < time.Second {
+		interval = time.Second // minimum
+	}
+
+	return requeryIntervalOption{
+		interval: interval,
+	}
+}
+
+func (o requeryIntervalOption) apply(provider *RequeryDNSHostProvider) {
+	provider.requeryInterval = o.interval
+}
+
+// RequeryDNSHostProvider is the default HostProvider. It currently matches
+// the Java StaticHostProvider, resolving hosts from DNS once during
+// the call to Init.  It could be easily extended to re-query DNS
+// periodically or if there is trouble connecting.
+type RequeryDNSHostProvider struct {
+	mu               sync.Mutex // Protects everything, so we can add asynchronous updates later.
+	servers          []string
+	curr             int
+	last             int
+	lookupTimeout    time.Duration
+	requeryInterval  time.Duration
+	dnsRequeryTicker *time.Ticker
+	lookupHost       lookupHostFn // Override of net.LookupHost, for testing.
+}
+
+// NewRequeryDNSHostProvider creates a new RequeryDNSHostProvider with the given options.
+func NewRequeryDNSHostProvider(options ...RequeryDNSHostProviderOption) *RequeryDNSHostProvider {
+	var provider RequeryDNSHostProvider
+	provider.lookupTimeout = _defaultLookupTimeout
+	provider.requeryInterval = _defaultRequeryInterval
+	for _, option := range options {
+		option.apply(&provider)
+	}
+	return &provider
+}
+
+// Init is called first, with the servers specified in the connection
+// string. It uses DNS to look up addresses for each server, then
+// shuffles them all together.
+func (hp *RequeryDNSHostProvider) Init(servers []string) error {
+	hp.mu.Lock()
+	defer hp.mu.Unlock()
+
+	zk.DefaultLogger.Printf("RequeryDNSHostProvider servers : %v", servers)
+	found, err := hp.resolveServerAddressList(servers)
+	if err != nil {
+		return err
+	}
+
+	zk.DefaultLogger.Printf("RequeryDNSHostProvider.Init servers=%s", found)
+	hp.servers = found
+	hp.curr = -1
+	hp.last = -1
+
+	hp.dnsRequeryTicker = time.NewTicker(hp.requeryInterval)
+	go func() {
+		for range hp.dnsRequeryTicker.C {
+			hp.lookupServers(servers)
+		}
+	}()
+
+	return nil
+}
+
+func (hp *RequeryDNSHostProvider) resolveServerAddressList(servers []string) ([]string, error) {
+	lookupHost := hp.lookupHost
+	if lookupHost == nil {
+		var resolver net.Resolver
+		lookupHost = resolver.LookupHost
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), hp.lookupTimeout)
+	defer cancel()
+
+	found := []string{}
+	for _, server := range servers {
+		host, port, err := net.SplitHostPort(server)
+		if err != nil {
+			return nil, err
+		}
+		addrs, err := lookupHost(ctx, host)
+		if err != nil {
+			return nil, err
+		}
+		for _, addr := range addrs {
+			found = append(found, net.JoinHostPort(addr, port))
+		}
+	}
+
+	if len(found) == 0 {
+		return nil, fmt.Errorf("No hosts found for addresses %q", servers)
+	}
+
+	// Randomize the order of the servers to avoid creating hotspots
+	stringShuffle(found)
+	return found, nil
+}
+
+func (hp *RequeryDNSHostProvider) lookupServers(servers []string) {
+	found, err := hp.resolveServerAddressList(servers)
+	if err != nil {
+		zk.DefaultLogger.Printf("resolveServerAddressList error. server=[%v] : %s", servers, err.Error())
+		return
+	}
+
+	if !isAddressChanged(hp.servers, found) {
+		return // same
+	}
+
+	hp.mu.Lock()
+	defer hp.mu.Unlock()
+
+	zk.DefaultLogger.Printf("RequeryDNSHostProvider.lookupServers servers=%s", found)
+	hp.servers = found
+	hp.curr = -1
+	hp.last = -1
+}
+
+func isAddressChanged(origin, candidate []string) bool {
+	for _, candidateAddr := range candidate {
+		candidateHost := strings.Split(candidateAddr, ":")[0]
+		exist := false
+		for _, originAddr := range origin {
+			originHost := strings.Split(originAddr, ":")[0]
+			if originHost == candidateHost {
+				exist = true
+				break
+			}
+		}
+		if !exist {
+			// 후보 서버 IP가 단 1개라도 기존 서버 목록에 존재하지 않으면 IP 가 변경된걸로 판단한다
+			return true
+		}
+	}
+
+	return false
+}
+
+// Len returns the number of servers available
+func (hp *RequeryDNSHostProvider) Len() int {
+	hp.mu.Lock()
+	defer hp.mu.Unlock()
+	return len(hp.servers)
+}
+
+// Next returns the next server to connect to. retryStart will be true
+// if we've looped through all known servers without Connected() being
+// called.
+func (hp *RequeryDNSHostProvider) Next() (server string, retryStart bool) {
+	hp.mu.Lock()
+	defer hp.mu.Unlock()
+	hp.curr = (hp.curr + 1) % len(hp.servers)
+	retryStart = hp.curr == hp.last
+	if hp.last == -1 {
+		hp.last = 0
+	}
+	return hp.servers[hp.curr], retryStart
+}
+
+// Connected notifies the HostProvider of a successful connection.
+func (hp *RequeryDNSHostProvider) Connected() {
+	hp.mu.Lock()
+	defer hp.mu.Unlock()
+	hp.last = hp.curr
+}
+
+// stringShuffle performs a Fisher-Yates shuffle on a slice of strings
+func stringShuffle(s []string) {
+	for i := len(s) - 1; i > 0; i-- {
+		j := rand.Intn(i + 1)
+		s[i], s[j] = s[j], s[i]
+	}
+}

--- a/requery_dnshost_provider.go
+++ b/requery_dnshost_provider.go
@@ -108,6 +108,14 @@ func NewRequeryDNSHostProvider(options ...RequeryDNSHostProviderOption) *Requery
 	return &provider
 }
 
+func (hp *RequeryDNSHostProvider) Close() {
+	if hp.dnsRequeryTicker != nil {
+		zk.DefaultLogger.Printf("dnsRequeryTicker closing")
+		hp.dnsRequeryTicker.Stop()
+		hp.dnsRequeryTicker = nil
+	}
+}
+
 // Init is called first, with the servers specified in the connection
 // string. It uses DNS to look up addresses for each server, then
 // shuffles them all together.

--- a/requery_dnshost_provider_test.go
+++ b/requery_dnshost_provider_test.go
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2025 github.com/fatima-go
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @project fatima-core
+ * @author dave_01
+ * @date 25. 4. 2. 오후 6:10
+ *
+ */
+
+package grpczk
+
+import (
+	"context"
+	"github.com/go-zookeeper/zk"
+	"github.com/stretchr/testify/assert"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	_devZkHostList = "zk.dev.music-flo.io:2181,zk.dev.music-flo.io:2182,zk.dev.music-flo.io:2183"
+)
+
+var (
+	_devZkAddressBefore = []string{"10.180.1.1", "10.180.1.2", "10.180.1.3"}
+	_devZkAddressAfter  = []string{"10.180.200.1", "10.180.200.2", "10.180.200.3"}
+)
+
+var (
+	dnsChanged = false
+)
+
+func TestNewRequeryDNSHostProvider(t *testing.T) {
+	// func(context.Context, string) ([]string, error)
+	dnsHostProvider := NewRequeryDNSHostProvider(
+		withLookupHost(mockLookupHost),
+		WithRequeryInterval(time.Second),
+	)
+
+	servers := zk.FormatServers(parseIpList(_devZkHostList))
+	err := dnsHostProvider.Init(servers)
+	if !assert.Nil(t, err) {
+		t.Fatalf("failed to init : %s", err.Error())
+		return
+	}
+
+	nextZkServerAddr, _ := dnsHostProvider.Next()
+	assert.True(t, containAddr(_devZkAddressBefore, nextZkServerAddr))
+	dnsChanged = true
+
+	time.Sleep(2 * time.Second) // wait for refresh tick
+
+	nextZkServerAddr, _ = dnsHostProvider.Next()
+	assert.True(t, containAddr(_devZkAddressAfter, nextZkServerAddr))
+}
+
+func containAddr(list []string, addr string) bool {
+	zk.DefaultLogger.Printf("containAddr : list=[%s], nextServer=%s", list, addr)
+	host := strings.Split(addr, ":")
+	for _, v := range list {
+		if v == host[0] {
+			return true
+		}
+	}
+	return false
+}
+
+var (
+	resolveIndex = 0
+)
+
+func mockLookupHost(ctx context.Context, host string) ([]string, error) {
+	index := resolveIndex % 3
+	if dnsChanged {
+		return []string{_devZkAddressAfter[index]}, nil
+	}
+	return []string{_devZkAddressBefore[index]}, nil
+}
+
+type lookupHostOption struct {
+	lookupFn lookupHostFn
+}
+
+func (o lookupHostOption) apply(provider *RequeryDNSHostProvider) {
+	provider.lookupHost = o.lookupFn
+}
+
+func withLookupHost(lookupFn lookupHostFn) RequeryDNSHostProviderOption {
+	return lookupHostOption{
+		lookupFn: lookupFn,
+	}
+}

--- a/zk_client_resolve.go
+++ b/zk_client_resolve.go
@@ -101,6 +101,11 @@ func hasServiceResolver(serviceName string) bool {
 }
 
 func updateServerList(serviceName string, newServerList []string) error {
+	if len(newServerList) == 0 {
+		zk.DefaultLogger.Printf("updateServerList is empty")
+		return nil // grpc server 목록이 비어 있다면 그대로 리턴
+	}
+
 	rmu.Lock()
 	defer rmu.Unlock()
 

--- a/zk_servant.go
+++ b/zk_servant.go
@@ -101,12 +101,12 @@ func (z *ZkServant) Connect() error {
 	if z.hostProvider != nil {
 		z.hostProvider.Close()
 	}
-	hostProvider := NewRequeryDNSHostProvider()
+	z.hostProvider = NewRequeryDNSHostProvider()
 
 	if z.debugging {
-		conn, eventChan, err = zk.Connect(z.ipList, time.Second, zk.WithHostProvider(hostProvider))
+		conn, eventChan, err = zk.Connect(z.ipList, time.Second, zk.WithHostProvider(z.hostProvider))
 	} else {
-		conn, eventChan, err = zk.Connect(z.ipList, time.Second, zk.WithLogInfo(false), zk.WithHostProvider(hostProvider))
+		conn, eventChan, err = zk.Connect(z.ipList, time.Second, zk.WithLogInfo(false), zk.WithHostProvider(z.hostProvider))
 	}
 	if err != nil {
 		return err

--- a/zk_servant.go
+++ b/zk_servant.go
@@ -96,10 +96,12 @@ func (z *ZkServant) Connect() error {
 	var conn *zk.Conn
 	var eventChan <-chan zk.Event
 	var err error
+	hostProvider := NewRequeryDNSHostProvider()
+
 	if z.debugging {
-		conn, eventChan, err = zk.Connect(z.ipList, time.Second)
+		conn, eventChan, err = zk.Connect(z.ipList, time.Second, zk.WithHostProvider(hostProvider))
 	} else {
-		conn, eventChan, err = zk.Connect(z.ipList, time.Second, zk.WithLogInfo(false))
+		conn, eventChan, err = zk.Connect(z.ipList, time.Second, zk.WithLogInfo(false), zk.WithHostProvider(hostProvider))
 	}
 	if err != nil {
 		return err

--- a/zk_servant.go
+++ b/zk_servant.go
@@ -58,6 +58,7 @@ type ZkServant struct {
 	debugging        bool
 	pathSet          map[string]struct{}
 	sessionAvailable bool
+	hostProvider     *RequeryDNSHostProvider
 }
 
 func NewZkServant(zkIpList string) *ZkServant {
@@ -96,6 +97,10 @@ func (z *ZkServant) Connect() error {
 	var conn *zk.Conn
 	var eventChan <-chan zk.Event
 	var err error
+
+	if z.hostProvider != nil {
+		z.hostProvider.Close()
+	}
 	hostProvider := NewRequeryDNSHostProvider()
 
 	if z.debugging {

--- a/zk_servant.go
+++ b/zk_servant.go
@@ -93,6 +93,8 @@ func (z *ZkServant) Connect() error {
 		return nil
 	}
 
+	zk.DefaultLogger.Printf("ZkServant.Connect...")
+
 	//(*Conn, <-chan Event, error)
 	var conn *zk.Conn
 	var eventChan <-chan zk.Event


### PR DESCRIPTION
[관련 이슈](https://github.com/fatima-go/grpczk/issues/19)

test 모듈은 아래와 같이 실행하면 됩니다 
_(다른 테스트 모듈은 테스트시 조건이 존재해서 사전 설정이 복잡하고, 지금 검증하려는 기능만 확인하도록...)_

```shell
go test -run TestNewRequeryDNSHostProvider
```

코드 PR 의 경우 `requery_dnshost_provider_test.go` 파일의 `func TestNewRequeryDNSHostProvider(..) `함수를 시작으로 살펴봐 주시면 되겠습니다.

아래는 코드가 선 반영된 dev 의 encryptd 모듈 로그입니다.

```shell
2025-04-03 10:42:16.706 INFO  [      g.g.z.conn.Connect():215] RequeryDNSHostProvider servers : [zk.dev.music-flo.io:2183 zk.dev.music-flo.io:2182 zk.dev.music-flo.io:2181]
2025-04-03 10:42:16.709 INFO  [      g.g.z.conn.Connect():215] RequeryDNSHostProvider.Init servers=[10.180.194.32:2182 10.180.194.32:2181 10.180.194.32:2183]
```